### PR TITLE
Improve number configuration UI with range support

### DIFF
--- a/src/Generador.java
+++ b/src/Generador.java
@@ -1,4 +1,5 @@
 import java.io.*;
+import java.math.BigDecimal;
 import java.util.*;
 import javax.swing.JOptionPane;
 import javax.script.ScriptEngine;
@@ -9,7 +10,7 @@ import javax.script.ScriptException;
 public class Generador {
     private boolean permitirDecimales = true;
     private boolean permitirNegativos = true;
-    private List<String> numeros;
+    private List<Double> numeros;
     private List<String> simbolos;
     private int cantidadOperaciones =2;
     private boolean permitirParentesis = false;
@@ -17,7 +18,10 @@ public class Generador {
 
  Generador() {
         String ruta = System.getProperty("user.dir") + "/";
-        numeros = leerLineas(ruta + "numeros.txt");
+        numeros = leerNumeros(ruta + "numeros.txt");
+        if (numeros.isEmpty()) {
+            mostrarErrorNumerosVacios();
+        }
         simbolos = leerSimbolosDesdeConfig(ruta + "simbolos.txt");
         if (simbolos.isEmpty()) {
             mostrarErrorSimbolosVacios();
@@ -47,14 +51,14 @@ public class Generador {
             intentos++;
 
             StringBuilder expresion = new StringBuilder();
-            double acumulador = Double.parseDouble(numeros.get(r.nextInt(numeros.size())));
+            double acumulador = numeros.get(r.nextInt(numeros.size()));
             expresion.append(acumulador);
 
             boolean valido = true;
 
             for (int i = 1; i < cantidadOperaciones; i++) {
                 String operador = simbolos.get(r.nextInt(simbolos.size()));
-                double siguiente = Double.parseDouble(numeros.get(r.nextInt(numeros.size())));
+                double siguiente = numeros.get(r.nextInt(numeros.size()));
 
                 if (operador.equals("/") && siguiente == 0) {
                     valido = false;
@@ -111,7 +115,7 @@ public class Generador {
         }
 
         // Fallback con varias divisiones exactas
-        double fallbackAcumulador = Double.parseDouble(numeros.get(r.nextInt(numeros.size())));
+        double fallbackAcumulador = numeros.get(r.nextInt(numeros.size()));
         StringBuilder expr = new StringBuilder(formatearNumero(fallbackAcumulador));
 
         for (int i = 1; i < cantidadOperaciones; i++) {
@@ -121,7 +125,7 @@ public class Generador {
                     divisor++;
                 }
             } else {
-                divisor = Double.parseDouble(numeros.get(r.nextInt(numeros.size())));
+                divisor = numeros.get(r.nextInt(numeros.size()));
                 if (divisor == 0) divisor = 1;
             }
 
@@ -361,8 +365,8 @@ public class Generador {
             }
 
          // Probar con distintos valores de X para encontrar uno que cumpla
-            double min = numeros.stream().mapToDouble(Double::parseDouble).min().orElse(-10);
-            double max = numeros.stream().mapToDouble(Double::parseDouble).max().orElse(10);
+            double min = numeros.stream().mapToDouble(Double::doubleValue).min().orElse(-10);
+            double max = numeros.stream().mapToDouble(Double::doubleValue).max().orElse(10);
 
             // Tomamos un número entero como resultado objetivo
             double resultadoEsperado = Math.round(min + r.nextDouble() * (max - min));
@@ -419,18 +423,104 @@ public class Generador {
         }
     }
 
-    private List<String> leerLineas(String ruta) {
-        List<String> out = new ArrayList<>();
+    private List<Double> leerNumeros(String ruta) {
+        List<Double> valores = new ArrayList<>();
         try (BufferedReader br = new BufferedReader(new FileReader(ruta))) {
             String linea;
             while ((linea = br.readLine()) != null) {
                 linea = linea.trim();
-                if (!linea.isEmpty()) out.add(linea);
+                if (linea.isEmpty()) {
+                    continue;
+                }
+
+                if (linea.contains("-")) {
+                    Optional<BigDecimal[]> rango = intentarParsearRango(linea);
+                    if (rango.isPresent()) {
+                        BigDecimal[] limites = rango.get();
+                        agregarRango(valores, limites[0], limites[1], linea);
+                        continue;
+                    }
+                }
+
+                try {
+                    valores.add(Double.parseDouble(linea));
+                } catch (NumberFormatException ex) {
+                    System.out.println("Valor de número inválido encontrado en " + ruta + ": " + linea);
+                }
             }
-        } catch (Exception e) {
-            System.out.println("Error al leer " + ruta);
+        } catch (IOException e) {
+            System.out.println("Error al leer " + ruta + ": " + e.getMessage());
         }
-        return out;
+        return valores;
+    }
+
+    private Optional<BigDecimal[]> intentarParsearRango(String linea) {
+        String expresion = linea.replaceAll("\\s+", "");
+        int separador = expresion.indexOf('-', 1); // ignora signo inicial si existe
+        if (separador <= 0 || separador >= expresion.length() - 1) {
+            return Optional.empty();
+        }
+
+        try {
+            BigDecimal inicio = new BigDecimal(expresion.substring(0, separador));
+            BigDecimal fin = new BigDecimal(expresion.substring(separador + 1));
+            if (inicio.compareTo(fin) <= 0) {
+                return Optional.of(new BigDecimal[]{inicio, fin});
+            }
+            return Optional.of(new BigDecimal[]{fin, inicio});
+        } catch (NumberFormatException ex) {
+            return Optional.empty();
+        }
+    }
+
+    private void agregarRango(List<Double> valores, BigDecimal inicioBD, BigDecimal finBD, String lineaOriginal) {
+
+        if (inicioBD.compareTo(finBD) == 0) {
+            valores.add(inicioBD.doubleValue());
+            return;
+        }
+
+        BigDecimal paso = determinarPaso(inicioBD, finBD);
+        if (paso.compareTo(BigDecimal.ZERO) <= 0) {
+            System.out.println("No se pudo determinar paso para el rango: " + lineaOriginal);
+            return;
+        }
+
+        int sizeAntes = valores.size();
+        for (BigDecimal actual = inicioBD; actual.compareTo(finBD) <= 0; actual = actual.add(paso)) {
+            valores.add(actual.doubleValue());
+            if (actual.add(paso).compareTo(actual) == 0) {
+                break; // evita bucle infinito si el paso es demasiado pequeño
+            }
+        }
+
+        double finDouble = finBD.doubleValue();
+        if (valores.size() == sizeAntes) {
+            valores.add(finDouble);
+            return;
+        }
+
+        double ultimo = valores.get(valores.size() - 1);
+        if (Math.abs(ultimo - finDouble) > 1e-9) {
+            valores.add(finDouble);
+        }
+    }
+
+    private BigDecimal determinarPaso(BigDecimal inicio, BigDecimal fin) {
+        int escala = Math.max(inicio.stripTrailingZeros().scale(), fin.stripTrailingZeros().scale());
+        if (escala < 0) {
+            escala = 0;
+        }
+        BigDecimal paso = BigDecimal.ONE.movePointLeft(escala);
+        if (paso.compareTo(BigDecimal.ZERO) <= 0) {
+            paso = BigDecimal.ONE;
+        }
+
+        BigDecimal diferencia = fin.subtract(inicio).abs();
+        if (diferencia.compareTo(paso) < 0) {
+            return diferencia;
+        }
+        return paso;
     }
     private List<String> leerSimbolosDesdeConfig(String ruta) {
         List<String> simbolos = new ArrayList<>();
@@ -520,16 +610,26 @@ public class Generador {
         );
         System.exit(0);
     }
+
+    private void mostrarErrorNumerosVacios() {
+        JOptionPane.showMessageDialog(
+            null,
+            "⚠ numeros.txt no contiene valores válidos.\n" +
+            "Revisa la configuración y asegúrate de definir números o rangos válidos (por ejemplo, 1-10).",
+            "Error de configuración",
+            JOptionPane.ERROR_MESSAGE
+        );
+        System.exit(0);
+    }
     private double getRandomNumero() {
-        return Double.parseDouble(numeros.get(new Random().nextInt(numeros.size())));
+        return numeros.get(new Random().nextInt(numeros.size()));
     }
 
     private double encontrarNumeroMasCercano(double objetivo) {
-        double cercano = Double.parseDouble(numeros.get(0));
+        double cercano = numeros.get(0);
         double diferenciaMinima = Math.abs(cercano - objetivo);
 
-        for (String s : numeros) {
-            double num = Double.parseDouble(s);
+        for (double num : numeros) {
             double diferencia = Math.abs(num - objetivo);
             if (diferencia < diferenciaMinima) {
                 cercano = num;


### PR DESCRIPTION
## Summary
- replace the free-form text area for números with a table-based editor that supports individual values and ranges
- add dialogs and validation to add, edit, or remove entries while persisting ranges back to numeros.txt
- format and validate numeric input, including handling invalid file entries gracefully

## Testing
- `javac -d bin src/*.java`


------
https://chatgpt.com/codex/tasks/task_e_6908a7e974cc8320b83dc43860267183