### PR TITLE
Alinear la presentación del modo inteligente con los ejercicios estándar

### DIFF
--- a/src/ModoDificultadInteligente.java
+++ b/src/ModoDificultadInteligente.java
@@ -1,26 +1,42 @@
 import javax.swing.*;
 import java.awt.*;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
-import java.awt.event.WindowAdapter;
-import java.awt.event.WindowEvent;
+import java.awt.event.*;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Random;
 
 public class ModoDificultadInteligente {
     private JFrame frame;
-    private JLabel lblProgreso;
+    private JPanel panelPrincipal;
+    private CardLayout cardLayout;
+    private JPanel panelEjercicio;
+    private JPanel panelCorreccion;
+    private JLabel lblTituloEjercicio;
     private JLabel lblNivel;
-    private JLabel lblEjercicio;
+    private JLabel lblCronometro;
+    private JLabel lblTextoEjercicio;
+    private JLabel lblCorreccionTitulo;
+    private JLabel lblCorreccionNivel;
+    private JLabel lblCorreccionEjercicio;
     private JLabel lblRetroalimentacion;
     private JTextField txtRespuesta;
     private JButton btnVerificar;
     private JButton btnContinuar;
+    private Timer timer;
+    private int segundos;
 
     private EjercicioMultiple ejercicioActual;
     private int ejerciciosTotales;
     private int ejerciciosCompletados;
     private int gradoDificultad;
+    private Color fondoEjercicioActual;
+
+    private enum EstadoPantalla {
+        EJERCICIO,
+        CORRECCION
+    }
+
+    private EstadoPantalla estadoPantalla = EstadoPantalla.EJERCICIO;
 
     public void iniciar() {
         LinkedHashMap<String, String> config = ConfigFileHelper.leerConfig();
@@ -41,10 +57,21 @@ public class ModoDificultadInteligente {
 
     private void construirUI() {
         frame = new JFrame("Modo dificultad inteligente");
-        frame.setSize(800, 600);
-        frame.setLocationRelativeTo(null);
+        frame.setUndecorated(true);
+        frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-        frame.setLayout(new BorderLayout(10, 10));
+        frame.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent e) {
+                if (e.getKeyCode() == KeyEvent.VK_ESCAPE) {
+                    cerrarModo();
+                } else if (estadoPantalla == EstadoPantalla.EJERCICIO && (e.getKeyCode() == KeyEvent.VK_SPACE || e.getKeyCode() == KeyEvent.VK_ENTER)) {
+                    mostrarCorreccion();
+                } else if (estadoPantalla == EstadoPantalla.CORRECCION && btnContinuar.isEnabled() && (e.getKeyCode() == KeyEvent.VK_SPACE || e.getKeyCode() == KeyEvent.VK_ENTER)) {
+                    continuar();
+                }
+            }
+        });
         frame.addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosed(WindowEvent e) {
@@ -52,54 +79,110 @@ public class ModoDificultadInteligente {
             }
         });
 
-        lblProgreso = crearEtiqueta("", 28, Font.BOLD, SwingConstants.CENTER);
-        lblNivel = crearEtiqueta("", 20, Font.PLAIN, SwingConstants.CENTER);
-
-        JPanel panelSuperior = new JPanel(new GridLayout(2, 1));
-        panelSuperior.add(lblProgreso);
-        panelSuperior.add(lblNivel);
-        frame.add(panelSuperior, BorderLayout.NORTH);
-
-        lblEjercicio = crearEtiqueta("", 48, Font.BOLD, SwingConstants.CENTER);
-        txtRespuesta = new JTextField();
-        txtRespuesta.setFont(new Font("Arial", Font.PLAIN, 32));
-        txtRespuesta.setHorizontalAlignment(SwingConstants.CENTER);
-
-        btnVerificar = new JButton("Verificar");
-        btnVerificar.setFont(new Font("Arial", Font.BOLD, 26));
-        btnVerificar.addActionListener(e -> verificarRespuesta());
-
-        btnContinuar = new JButton("Siguiente");
-        btnContinuar.setFont(new Font("Arial", Font.BOLD, 26));
-        btnContinuar.setEnabled(false);
-        btnContinuar.addActionListener(new ActionListener() {
+        frame.addMouseListener(new MouseAdapter() {
             @Override
-            public void actionPerformed(ActionEvent e) {
-                continuar();
+            public void mouseClicked(MouseEvent e) {
+                if (estadoPantalla == EstadoPantalla.EJERCICIO) {
+                    mostrarCorreccion();
+                }
             }
         });
 
+        cardLayout = new CardLayout();
+        panelPrincipal = new JPanel(cardLayout);
+        frame.getContentPane().add(panelPrincipal);
+
+        construirPanelEjercicio();
+        construirPanelCorreccion();
+    }
+
+    private void construirPanelEjercicio() {
+        panelEjercicio = new JPanel(new BorderLayout());
+        panelEjercicio.setBackground(Color.WHITE);
+
+        JPanel panelSuperior = new JPanel(new BorderLayout());
+        panelSuperior.setOpaque(false);
+
+        lblCronometro = crearEtiqueta("⏱ 0s", 50, Font.PLAIN, SwingConstants.LEFT);
+        lblCronometro.setForeground(Color.BLUE);
+        panelSuperior.add(lblCronometro, BorderLayout.WEST);
+
+        lblTituloEjercicio = crearEtiqueta("", 60, Font.BOLD, SwingConstants.CENTER);
+        lblTituloEjercicio.setForeground(Color.DARK_GRAY);
+        panelSuperior.add(lblTituloEjercicio, BorderLayout.CENTER);
+
+        lblNivel = crearEtiqueta("", 24, Font.PLAIN, SwingConstants.RIGHT);
+        lblNivel.setForeground(Color.DARK_GRAY);
+        panelSuperior.add(lblNivel, BorderLayout.EAST);
+
+        panelEjercicio.add(panelSuperior, BorderLayout.NORTH);
+
+        lblTextoEjercicio = crearEtiqueta("", 70, Font.BOLD, SwingConstants.CENTER);
+        lblTextoEjercicio.setVerticalAlignment(SwingConstants.CENTER);
+        panelEjercicio.add(lblTextoEjercicio, BorderLayout.CENTER);
+
+        panelPrincipal.add(panelEjercicio, EstadoPantalla.EJERCICIO.name());
+    }
+
+    private void construirPanelCorreccion() {
+        panelCorreccion = new JPanel(new BorderLayout(20, 20));
+        panelCorreccion.setBackground(Color.WHITE);
+
+        JPanel panelSuperior = new JPanel(new BorderLayout());
+        panelSuperior.setOpaque(false);
+
+        lblCorreccionTitulo = crearEtiqueta("Corrección", 60, Font.BOLD, SwingConstants.CENTER);
+        lblCorreccionTitulo.setForeground(Color.DARK_GRAY);
+        panelSuperior.add(lblCorreccionTitulo, BorderLayout.CENTER);
+
+        lblCorreccionNivel = crearEtiqueta("", 24, Font.PLAIN, SwingConstants.RIGHT);
+        lblCorreccionNivel.setForeground(Color.DARK_GRAY);
+        panelSuperior.add(lblCorreccionNivel, BorderLayout.EAST);
+
+        panelCorreccion.add(panelSuperior, BorderLayout.NORTH);
+
         JPanel panelCentro = new JPanel();
+        panelCentro.setOpaque(false);
         panelCentro.setLayout(new BoxLayout(panelCentro, BoxLayout.Y_AXIS));
-        panelCentro.add(Box.createVerticalStrut(40));
-        panelCentro.add(lblEjercicio);
-        panelCentro.add(Box.createVerticalStrut(20));
+
+        lblCorreccionEjercicio = crearEtiqueta("", 50, Font.BOLD, SwingConstants.CENTER);
+        lblCorreccionEjercicio.setAlignmentX(Component.CENTER_ALIGNMENT);
+        panelCentro.add(lblCorreccionEjercicio);
+        panelCentro.add(Box.createVerticalStrut(30));
+
+        txtRespuesta = new JTextField();
+        txtRespuesta.setFont(new Font("Arial", Font.PLAIN, 36));
+        txtRespuesta.setHorizontalAlignment(SwingConstants.CENTER);
+        txtRespuesta.setMaximumSize(new Dimension(600, 70));
         panelCentro.add(txtRespuesta);
         panelCentro.add(Box.createVerticalStrut(20));
 
+        lblRetroalimentacion = crearEtiqueta("", 28, Font.PLAIN, SwingConstants.CENTER);
+        lblRetroalimentacion.setForeground(Color.DARK_GRAY);
+        lblRetroalimentacion.setAlignmentX(Component.CENTER_ALIGNMENT);
+        panelCentro.add(lblRetroalimentacion);
+        panelCentro.add(Box.createVerticalStrut(20));
+
         JPanel panelBotones = new JPanel();
-        panelBotones.setAlignmentX(Component.CENTER_ALIGNMENT);
+        panelBotones.setOpaque(false);
+
+        btnVerificar = new JButton("Verificar");
+        btnVerificar.setFont(new Font("Arial", Font.BOLD, 30));
+        btnVerificar.addActionListener(e -> verificarRespuesta());
         panelBotones.add(btnVerificar);
+
+        btnContinuar = new JButton("Siguiente");
+        btnContinuar.setFont(new Font("Arial", Font.BOLD, 30));
+        btnContinuar.setEnabled(false);
+        btnContinuar.addActionListener(e -> continuar());
         panelBotones.add(Box.createHorizontalStrut(20));
         panelBotones.add(btnContinuar);
+
         panelCentro.add(panelBotones);
 
-        lblRetroalimentacion = crearEtiqueta("", 22, Font.PLAIN, SwingConstants.CENTER);
-        lblRetroalimentacion.setForeground(Color.DARK_GRAY);
-        panelCentro.add(Box.createVerticalStrut(20));
-        panelCentro.add(lblRetroalimentacion);
+        panelCorreccion.add(panelCentro, BorderLayout.CENTER);
 
-        frame.add(panelCentro, BorderLayout.CENTER);
+        panelPrincipal.add(panelCorreccion, EstadoPantalla.CORRECCION.name());
     }
 
     private JLabel crearEtiqueta(String texto, int tamanioFuente, int estilo, int alineacion) {
@@ -123,18 +206,21 @@ public class ModoDificultadInteligente {
             return;
         }
 
-        lblProgreso.setText("Ejercicio " + (ejerciciosCompletados + 1) + " de " + ejerciciosTotales);
+        lblTituloEjercicio.setText("Ejercicio " + (ejerciciosCompletados + 1) + " de " + ejerciciosTotales);
         lblNivel.setText(descripcionNivel(nivelActual));
-        lblEjercicio.setText(ejercicioActual.getEjercicioTexto());
-        lblRetroalimentacion.setText("");
+        lblTextoEjercicio.setText(ejercicioActual.getEjercicioTexto());
 
-        txtRespuesta.setText("");
-        txtRespuesta.setEditable(true);
-        txtRespuesta.requestFocusInWindow();
+        fondoEjercicioActual = generarColorPastelAleatorio();
+        panelEjercicio.setBackground(fondoEjercicioActual);
 
-        btnVerificar.setEnabled(true);
-        btnContinuar.setEnabled(false);
-        btnContinuar.setText("Siguiente");
+        segundos = 0;
+        lblCronometro.setText("⏱ 0s");
+        iniciarContador();
+
+        estadoPantalla = EstadoPantalla.EJERCICIO;
+        cardLayout.show(panelPrincipal, EstadoPantalla.EJERCICIO.name());
+        frame.getContentPane().revalidate();
+        frame.getContentPane().repaint();
     }
 
     private EjercicioMultiple generarEjercicio(NivelDificultad nivel) {
@@ -151,6 +237,10 @@ public class ModoDificultadInteligente {
     }
 
     private void verificarRespuesta() {
+        if (estadoPantalla != EstadoPantalla.CORRECCION) {
+            return;
+        }
+
         String texto = txtRespuesta.getText().trim().replace(",", ".");
         if (texto.isEmpty()) {
             mostrarMensaje("Ingresa una respuesta antes de verificar.", Color.RED);
@@ -182,6 +272,7 @@ public class ModoDificultadInteligente {
         NivelDificultad nivelActual = obtenerNivelActual();
         if (nivelActual != null) {
             lblNivel.setText(descripcionNivel(nivelActual));
+            lblCorreccionNivel.setText(descripcionNivel(nivelActual));
         }
 
         btnVerificar.setEnabled(false);
@@ -190,6 +281,31 @@ public class ModoDificultadInteligente {
         if (ejerciciosCompletados >= ejerciciosTotales) {
             btnContinuar.setText("Finalizar");
         }
+    }
+
+    private void mostrarCorreccion() {
+        if (estadoPantalla != EstadoPantalla.EJERCICIO) {
+            return;
+        }
+
+        detenerContador();
+        estadoPantalla = EstadoPantalla.CORRECCION;
+
+        lblCorreccionTitulo.setText("Corrección - Ejercicio " + (ejerciciosCompletados + 1) + " de " + ejerciciosTotales);
+        lblCorreccionNivel.setText(lblNivel.getText());
+        lblCorreccionEjercicio.setText(ejercicioActual.getEjercicioTexto());
+        lblRetroalimentacion.setText("");
+
+        txtRespuesta.setText("");
+        txtRespuesta.setEditable(true);
+        btnVerificar.setEnabled(true);
+        btnContinuar.setEnabled(false);
+        btnContinuar.setText("Siguiente");
+
+        panelCorreccion.setBackground(fondoEjercicioActual != null ? fondoEjercicioActual : Color.WHITE);
+
+        cardLayout.show(panelPrincipal, EstadoPantalla.CORRECCION.name());
+        SwingUtilities.invokeLater(() -> txtRespuesta.requestFocusInWindow());
     }
 
     private String descripcionNivel(NivelDificultad nivelActual) {
@@ -236,6 +352,7 @@ public class ModoDificultadInteligente {
     }
 
     private void cerrarModo() {
+        detenerContador();
         JOptionPane.showMessageDialog(frame,
                 "Has terminado el modo dificultad inteligente. Grado final: " + gradoDificultad + " pts.");
         frame.dispose();
@@ -247,5 +364,29 @@ public class ModoDificultadInteligente {
         } catch (NumberFormatException e) {
             return predeterminado;
         }
+    }
+
+    private void iniciarContador() {
+        detenerContador();
+        timer = new Timer(1000, e -> {
+            segundos++;
+            lblCronometro.setText("⏱ " + segundos + "s");
+        });
+        timer.start();
+    }
+
+    private void detenerContador() {
+        if (timer != null) {
+            timer.stop();
+            timer = null;
+        }
+    }
+
+    private Color generarColorPastelAleatorio() {
+        Random random = new Random();
+        int red = (random.nextInt(128) + 127);
+        int green = (random.nextInt(128) + 127);
+        int blue = (random.nextInt(128) + 127);
+        return new Color(red, green, blue);
     }
 }

--- a/src/ModoDificultadInteligente.java
+++ b/src/ModoDificultadInteligente.java
@@ -314,16 +314,7 @@ public class ModoDificultadInteligente {
             filaSuperior.add(lblEjercicio);
             filaSuperior.add(Box.createHorizontalStrut(30));
 
-            JLabel lblRetro = crearEtiqueta("", 28, Font.PLAIN, SwingConstants.LEFT);
-            lblRetro.setForeground(Color.DARK_GRAY);
-            lblRetro.setAlignmentY(Component.CENTER_ALIGNMENT);
-            Dimension dialogoDimension = new Dimension(450, 70);
-            lblRetro.setPreferredSize(dialogoDimension);
-            lblRetro.setMaximumSize(new Dimension(600, 80));
-            lblRetro.setMinimumSize(new Dimension(320, 60));
-            filaSuperior.add(lblRetro);
-            filaSuperior.add(Box.createHorizontalStrut(30));
-
+            
             JTextField campoRespuesta = new JTextField();
             campoRespuesta.setFont(new Font("Arial", Font.PLAIN, 36));
             campoRespuesta.setHorizontalAlignment(SwingConstants.CENTER);
@@ -334,6 +325,16 @@ public class ModoDificultadInteligente {
             campoRespuesta.setAlignmentY(Component.CENTER_ALIGNMENT);
             filaSuperior.add(campoRespuesta);
             filaSuperior.add(Box.createHorizontalGlue());
+            
+            JLabel lblRetro = crearEtiqueta("", 28, Font.PLAIN, SwingConstants.LEFT);
+            lblRetro.setForeground(Color.DARK_GRAY);
+            lblRetro.setAlignmentY(Component.CENTER_ALIGNMENT);
+            Dimension dialogoDimension = new Dimension(450, 70);
+            lblRetro.setPreferredSize(dialogoDimension);
+            lblRetro.setMaximumSize(new Dimension(600, 80));
+            lblRetro.setMinimumSize(new Dimension(320, 60));
+            filaSuperior.add(lblRetro);
+            filaSuperior.add(Box.createHorizontalStrut(30));
 
             fila.add(filaSuperior);
 


### PR DESCRIPTION
## Summary
- actualizar el modo de dificultad inteligente para mostrar los ejercicios con la misma presentación a pantalla completa que el flujo de "Comenzar ejercicios"
- agregar una diapositiva de corrección con campo de respuesta y retroalimentación para verificar cada resultado sin perder la adaptación de dificultad
- incorporar cronómetro, color de fondo y navegación por tarjetas para mantener la experiencia unificada

## Testing
- javac src/*.java

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691283ec0800832096c631ce1abb9660)