### PR TITLE
Ajusta dificultad inteligente y reemplaza niveles por CSV

### DIFF
--- a/niveles_dificultad.csv
+++ b/niveles_dificultad.csv
@@ -1,0 +1,4 @@
+descripcion,min,max,operaciones,ejercicios,decimales,negativos,parentesis,despejarX,operadores,numeros
+"Nivel 1 (0 a 5 pts)",0,5,2,7,NO,NO,NO,NO,+,"1-10"
+"Nivel 2 (6 a 10 pts)",6,10,2,7,NO,NO,NO,NO,+,"1-50"
+"Nivel 3 (11 a 15 pts)",11,15,3,7,NO,NO,NO,NO,"+,-","1-50"

--- a/niveles_dificultad.txt
+++ b/niveles_dificultad.txt
@@ -1,4 +1,0 @@
-# descripcion|min|max|operaciones|ejercicios|decimales(SI/NO)|negativos(SI/NO)|parentesis(SI/NO)|despejarX(SI/NO)|operadores separados por coma|numeros (usar ; para separar rangos o valores)
-Nivel 1 (0 a 5 pts)|0|5|2|7|NO|NO|NO|NO|+|1-10
-Nivel 2 (6 a 10 pts)|6|10|2|7|NO|NO|NO|NO|+|1-50
-Nivel 3 (11 a 15 pts)|11|15|3|7|NO|NO|NO|NO|+,-|1-50

--- a/src/ModoDificultadInteligente.java
+++ b/src/ModoDificultadInteligente.java
@@ -3,6 +3,7 @@ import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import java.awt.*;
 import java.awt.event.*;
+import java.awt.image.BufferedImage;
 import java.time.LocalDate;
 import java.time.format.TextStyle;
 import java.util.ArrayList;
@@ -250,7 +251,9 @@ public class ModoDificultadInteligente {
 
         lblTituloEjercicio.setText("Ejercicio " + ejerciciosGenerados.size() + " de " + ejerciciosTotales);
         lblNivel.setText(descripcionNivel(nivelActual));
-        lblTextoEjercicio.setText(ejercicioActual.getEjercicioTexto());
+        String textoEjercicio = ejercicioActual.getEjercicioTexto();
+        lblTextoEjercicio.setText(textoEjercicio);
+        ajustarTamanoFuenteEjercicio(textoEjercicio);
 
         panelEjercicio.setBackground(generarColorPastelAleatorio());
 
@@ -262,6 +265,31 @@ public class ModoDificultadInteligente {
         cardLayout.show(panelPrincipal, EstadoPantalla.EJERCICIO.name());
         frame.getContentPane().revalidate();
         frame.getContentPane().repaint();
+    }
+
+    private void ajustarTamanoFuenteEjercicio(String texto) {
+        int fontSize = calcularTamanoFuente(texto, Toolkit.getDefaultToolkit().getScreenSize().width * 0.7);
+        lblTextoEjercicio.setFont(new Font("Arial", Font.BOLD, fontSize));
+    }
+
+    private int calcularTamanoFuente(String texto, double anchoObjetivo) {
+        if (texto == null || texto.isEmpty()) {
+            return 70;
+        }
+        int objetivo = (int) Math.max(100, anchoObjetivo);
+        BufferedImage img = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D g2d = img.createGraphics();
+        int fontSize = 10;
+        int anchoTexto;
+        do {
+            Font font = new Font("Arial", Font.BOLD, fontSize);
+            g2d.setFont(font);
+            FontMetrics metrics = g2d.getFontMetrics();
+            anchoTexto = metrics.stringWidth(texto);
+            fontSize++;
+        } while (anchoTexto < objetivo && fontSize < 300);
+        g2d.dispose();
+        return Math.max(20, fontSize - 1);
     }
 
     private EjercicioMultiple generarEjercicio(NivelDificultad nivel) {


### PR DESCRIPTION
## Summary
- adapta el texto de los ejercicios de dificultad inteligente para que escale con el tamaño de pantalla
- migra la definición de niveles de dificultad al nuevo archivo CSV y ajusta la carga/guardado

## Testing
- javac src/*.java

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912a19e75a083208a28ff45c37f1e6e)